### PR TITLE
Carthage: Update CocoaAsyncSocket to 7.6.x and Weak to "head"

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -4,7 +4,7 @@
 github "pryomoax/SwiftAbstractLogger.git" ~> 0.2
 
 # GCDAsyncSocket
-github "robbiehanson/CocoaAsyncSocket" ~> 7.5
+github "robbiehanson/CocoaAsyncSocket" ~> 7.6
 
 # Weak
-github "nvzqz/Weak" ~> 1.0
+github "nvzqz/Weak" "head"


### PR DESCRIPTION
Fixes dependency compile errors in XCode 9