### PR TITLE
Fix for issue #14: location header not always capitalized by UPnP devices

### DIFF
--- a/SwiftSSDP/SSDPResponse.swift
+++ b/SwiftSSDP/SSDPResponse.swift
@@ -18,6 +18,25 @@ public enum SSDPMessage {
     case notify
 }
 
+/// Case insensitive indexing for things like location etc
+extension Dictionary where Key == String {
+
+    subscript(caseInsensitive key: Key) -> Value? {
+        get {
+            if let k = keys.first(where: { $0.caseInsensitiveCompare(key) == .orderedSame }) {
+                return self[k]
+            }
+            return nil
+        }
+        set {
+            if let k = keys.first(where: { $0.caseInsensitiveCompare(key) == .orderedSame }) {
+                self[k] = newValue
+            } else {
+                self[key] = newValue
+            }
+        }
+    }
+}
 //
 // MARK: -
 //
@@ -203,7 +222,7 @@ extension SSDPMSearchResponse {
         mutableHeaders.removeValue(forKey: SSDPHeaderKeys.ext)
         
         // LOCATION
-        guard let location = headers[SSDPHeaderKeys.location], let locationUrl = URL(string: location) else {
+        guard let location = headers[caseInsensitive:SSDPHeaderKeys.location], let locationUrl = URL(string: location) else {
             return nil
         }
         self.location = locationUrl


### PR DESCRIPTION
use a simple (naive) case insensitive dictionary lookup for the location